### PR TITLE
Prevent loading own pytest plugin to not mess up coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ addopts = """
     --cov-report html
     -W error
     -vvv
+    -p no:numthreads
 """
 
 [tool.coverage.run]


### PR DESCRIPTION


<!-- readthedocs-preview numthreads start -->
----
📚 Documentation preview 📚: https://numthreads--11.org.readthedocs.build/en/11/

<!-- readthedocs-preview numthreads end -->